### PR TITLE
Fix errors during SMF 1.1 conversion to ElkArte

### DIFF
--- a/importer/Importers/elkarte1.0/smf1-1_importer.php
+++ b/importer/Importers/elkarte1.0/smf1-1_importer.php
@@ -98,7 +98,7 @@ function moveAttachment($row, $db, $from_prefix, $attachmentUploadDir)
 	}
 
 	// If something is broken, better try to account for it as well.
-	if (isset($smf_folders[$row['id_folder']]))
+	if (isset($row['id_folder']) && isset($smf_folders[$row['id_folder']]))
 		$smf_attachments_dir = $smf_folders[$row['id_folder']];
 	else
 		$smf_attachments_dir = $smf_folders[1];

--- a/importer/Importers/elkarte1.0/smf1-1_importer.xml
+++ b/importer/Importers/elkarte1.0/smf1-1_importer.xml
@@ -198,7 +198,7 @@
 			SELECT
 				ID_MEMBER as id_member, memberName AS member_name, dateRegistered AS date_registered, 
 				posts, ID_GROUP as id_group, lngfile, lastLogin AS last_login,
-				realName AS real_name, instantMessages AS instant_messages,
+				realName AS real_name, instantMessages AS personal_messages,
 				unreadMessages AS unread_messages, buddy_list, pm_ignore_list,
 				messageLabels AS message_labels, passwd, emailAddress AS email_address,
 				personalText AS personal_text, gender, birthdate, websiteUrl AS website_url,
@@ -331,10 +331,10 @@
 		</options>
 		<query>
 			SELECT
-				ID_MSG AS id_msg, ID_TOPIC AS id_topic, ID_BOARD AS id_board, posterTime AS poster_time
+				ID_MSG AS id_msg, ID_TOPIC AS id_topic, ID_BOARD AS id_board, posterTime AS poster_time,
 				ID_MEMBER AS id_member, ID_MSG_MODIFIED AS id_msg_modified,
 				subject, posterName AS poster_name, posterEmail AS poster_email,
-				posterIP AS poster_ip, smileys_enabled AS smileys_enabled, 
+				posterIP AS poster_ip, smileysEnabled AS smileys_enabled, 
 				modifiedTime AS modified_time, modifiedName AS modified_name, body, icon
 			FROM {$from_prefix}messages;
 		</query>


### PR DESCRIPTION
I encountered a number of fatal errors while converting from SMF 1.1 to ElkArte. These are the code fixes that had to be made just to get the conversion to run.

Signed-off-by: Noteworthy Software, Inc online@noteworthysoftware.com
