### PR TITLE
Use id_pm as default value for id_pm_head in personal_messages (SMF 1.1 -> ElkArte)

### DIFF
--- a/importer/Importers/elkarte1.0/smf1-1_importer.xml
+++ b/importer/Importers/elkarte1.0/smf1-1_importer.xml
@@ -384,7 +384,7 @@
 		</options>
 		<query>
 			SELECT
-				ID_PM AS id_pm, ID_MEMBER_FROM AS id_member_from, deletedBySender AS deleted_by_sender,
+				ID_PM AS id_pm, ID_PM AS id_pm_head, ID_MEMBER_FROM AS id_member_from, deletedBySender AS deleted_by_sender,
 				fromName AS from_name, msgtime, subject, body
 			FROM {$from_prefix}personal_messages;
 		</query>


### PR DESCRIPTION
This change emulates the personal message threading scheme
used by SMF 1.1 to 2.0 upgrade script. It simply creates a
separate thread for each message. Without this change, all
imported messages get grouped into the same null message
thread.

Signed-off-by: Noteworthy Software, Inc online@noteworthysoftware.com
