### PR TITLE
Fix attachment mime_type and fileext SMF 1.1->ElkArte

### DIFF
--- a/importer/Importers/elkarte1.0/smf1-1_importer.php
+++ b/importer/Importers/elkarte1.0/smf1-1_importer.php
@@ -111,5 +111,37 @@ function moveAttachment(&$row, $db, $from_prefix, $attachmentUploadDir)
 	else
 		$source_file = $row['id_attach'] . '_' . $row['file_hash'];
 
+	if (empty($row['mime_type']))
+	{
+		$fileext = '';
+		$mimetype = '';
+		$is_thumb = false;
+
+		if (preg_match('/\.(jpg|jpeg|gif|png)(_thumb)?$/i',$row['filename'],$m))
+		{
+			$fileext = strtolower($m[1]);
+			$is_thumb = !empty($m[2]);
+
+			if (empty($row['mime_type']))
+			{
+				// AFAIK, all thumbnails got created as PNG
+				if ($is_thumb) $mimetype = 'image/png';
+				elseif ($fileext == 'jpg') $mimetype = 'image/jpeg';
+				else $mimetype = 'image/'.$fileext;
+			}
+		}
+		else if (preg_match('/\.([a-z][a-z0-9]*)$/i',$row['filename'],$m))
+		{
+			$fileext = strtolower($m[1]);
+		}
+
+		if (empty($row['fileext'])) $row['fileext'] = $fileext;
+
+		// try using getimagesize to calculate the mime type, otherwise use the $mimetype set from above
+		$size = @getimagesize($filename);
+
+		$row['mime_type'] = empty($size['mime']) ? $mimetype : $size['mime'];
+	}
+
 	copy_file($smf_attachments_dir . '/' . $source_file, $attachmentUploadDir . '/' . $row['id_attach'] . '_' . $row['file_hash'] . '.elk');
 }

--- a/importer/Importers/elkarte1.0/smf1-1_importer.xml
+++ b/importer/Importers/elkarte1.0/smf1-1_importer.xml
@@ -227,8 +227,8 @@
 		<query>
 			SELECT
 				ID_ATTACH AS id_attach, ID_THUMB AS id_thumb, ID_MSG AS id_msg, ID_MEMBER AS id_member,
-				attachmentType AS attachment_type, filename, file_hash, size, downloads,
-				width, height
+				attachmentType AS attachment_type, filename, file_hash, '' AS fileext,size, downloads,
+				width, height,'' AS mime_type
 			FROM {$from_prefix}attachments;
 		</query>
 	</step>


### PR DESCRIPTION
SMF 1.1 forum attachments do not have mime_type or fileext settings, so they must be calculated. This updates the moveAttachment function to setup these fields in a manner somewhat consistent with what is done by the [SMF 2.0 upgrade script](https://github.com/SimpleMachines/SMF2.1/blob/release-2.1/other/upgrade_2-0_mysql.sql).

Without this change, all existing image attachments lack a mime_type after importing/converting. This causes big problems for Internet Explorer.

Signed-off-by: Noteworthy Software, Inc online@noteworthysoftware.com
