### PR TITLE
Convert <br> to <br /> for elk_messages body

### DIFF
--- a/importer/Importers/elkarte1.0/smf1-1_importer.xml
+++ b/importer/Importers/elkarte1.0/smf1-1_importer.xml
@@ -335,7 +335,8 @@
 				ID_MEMBER AS id_member, ID_MSG_MODIFIED AS id_msg_modified,
 				subject, posterName AS poster_name, posterEmail AS poster_email,
 				posterIP AS poster_ip, smileysEnabled AS smileys_enabled, 
-				modifiedTime AS modified_time, modifiedName AS modified_name, body, icon
+				modifiedTime AS modified_time, modifiedName AS modified_name,
+				REPLACE(body, '<br>', '<br />') as body, icon
 			FROM {$from_prefix}messages;
 		</query>
 	</step>


### PR DESCRIPTION
Our SMF 1.1 forum has `<br>` tags in all message bodies. This causes some problems in Elk. For example, compact search results actually show the `<br>` tags.

Signed-off-by: Noteworthy Software, Inc <online@noteworthysoftware.com>