### PR TITLE
Some more minor fixes

### DIFF
--- a/importer/Importers/destinations/SmfCommonOriginStep1.php
+++ b/importer/Importers/destinations/SmfCommonOriginStep1.php
@@ -226,8 +226,8 @@ abstract class SmfCommonOriginStep1 extends Step1BaseImporter
 			$return = array(
 				'id_attach' => $id_attach,
 				'size' => filesize($source),
-				'filename' => '\'' . $row['filename'] . '\'',
-				'file_hash' => '\'' . $file_hash . '\'',
+				'filename' => $row['filename'],
+				'file_hash' => $file_hash,
 				'id_member' => $row['id_member'],
 				'id_folder' => $avatar_attach_folder,
 			);

--- a/importer/Importers/destinations/SmfCommonOriginStep1.php
+++ b/importer/Importers/destinations/SmfCommonOriginStep1.php
@@ -263,9 +263,9 @@ abstract class SmfCommonOriginStep1 extends Step1BaseImporter
 
 	public function beforeAttachments()
 	{
+		$this->removeAttachments();
 		$this->db->query("
 			TRUNCATE {$this->config->to_prefix}attachments");
-		$this->removeAttachments();
 
 		$this->config->destination->specialAttachments();
 	}

--- a/importer/OpenImporter/ImportManager.php
+++ b/importer/OpenImporter/ImportManager.php
@@ -392,7 +392,7 @@ class ImportManager
 	{
 		$this->cookie->destroy();
 		//previously imported? we need to clean some variables ..
-		unset($_SESSION['importer_data'], $_SESSION['importer_progress_status']);
+		unset($_SESSION['importer_data'], $_SESSION['importer_progress_status'], $_SESSION['import_progress']);
 
 		if ($this->detectScripts())
 			return true;
@@ -504,6 +504,7 @@ class ImportManager
 		unset($_SESSION['import_progress']);
 		unset($_SESSION['importer_data'], $_SESSION['importer_progress_status']);
 		$this->data = array();
+		$this->config->store = array();
 
 		return true;
 	}


### PR DESCRIPTION
* I don't see where the function beforeAttachments is even called (yay OOP ignorance...) but, if we are going to remove attachments based on the content of {to_prefix}attachments, it's probably better to do it before we TRUNCATE the table?

* Avatars filename and hash had extra \' which rendered them invalid (fixes #71)

* At the end of the conversion, if I wanted to perform another conversion, only "attachments", "avatars" and "recount" totals are performed (every other steps were just skipped, not even listed)
