### PR TITLE
SMF 2.0 -> Elkarte 1.1 Importer

### DIFF
--- a/importer/Importers/elkarte1.0/smf2-0_importer.xml
+++ b/importer/Importers/elkarte1.0/smf2-0_importer.xml
@@ -172,6 +172,17 @@
 				'paypal_email',
 				'smiley_enable',
 				'messageIcons_enable',
+				'disableHostnameLookup',
+				'approveAccountDeletion',
+				'avatar_download_external',
+				'spider_mode',
+				'calendar_updated',
+				'coppaAge',
+				'disallow_sendBody',
+				'enableErrorQueryLogging',
+				'hitStats',
+				'password_strength',
+				'mail_queue',
 			);
 
 			$request = $this->db->query("

--- a/importer/Importers/elkarte1.1/elkarte1.1_importer.php
+++ b/importer/Importers/elkarte1.1/elkarte1.1_importer.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * @name      OpenImporter
+ * @copyright OpenImporter contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause
+ *
+ * @version 1.0 Alpha
+ *
+ * This file contains code based on:
+ *
+ * Simple Machines Forum (SMF)
+ * copyright:	2011 Simple Machines (http://www.simplemachines.org)
+ * license:	BSD, See included LICENSE.TXT for terms and conditions.
+ */
+
+/**
+ * The class contains code that allows the Importer to obtain settings
+ * from the ElkArte installation.
+ */
+class elkarte1_1_importer extends Importers\SmfCommonSource
+{
+	/**
+	 * @var string
+	 */
+	public $attach_extension = 'elk';
+
+	/**
+	 * @return string
+	 */
+	public function getName()
+	{
+		return 'ElkArte 1.1';
+	}
+}
+
+class elkarte1_1_importer_step1 extends Importers\SmfCommonSourceStep1
+{
+}
+
+class elkarte1_1_importer_step2 extends Importers\SmfCommonSourceStep2
+{
+	/**
+	 * Repair any wrong number of personal messages
+	 */
+	public function substep0()
+	{
+		$to_prefix = $this->config->to_prefix;
+
+		// Get all members with wrong number of personal messages and fix it
+		$request = $this->db->query("
+			SELECT
+				mem.id_member, COUNT(pmr.id_pm) AS real_num, mem.personal_messages
+			FROM {$to_prefix}members AS mem
+				LEFT JOIN {$to_prefix}pm_recipients AS pmr ON (mem.id_member = pmr.id_member AND pmr.deleted = 0)
+			GROUP BY mem.id_member
+			HAVING real_num != personal_messages");
+		while ($row = $this->db->fetch_assoc($request))
+		{
+			$this->db->query("
+				UPDATE {$to_prefix}members
+				SET personal_messages = $row[real_num]
+				WHERE id_member = $row[id_member]
+				LIMIT 1");
+
+			pastTime(0);
+		}
+		$this->db->free_result($request);
+
+		$request = $this->db->query("
+			SELECT
+				mem.id_member, COUNT(pmr.id_pm) AS real_num, mem.unread_messages
+			FROM {$to_prefix}members AS mem
+				LEFT JOIN {$to_prefix}pm_recipients AS pmr ON (mem.id_member = pmr.id_member AND pmr.deleted = 0 AND pmr.is_read = 0)
+			GROUP BY mem.id_member
+			HAVING real_num != unread_messages");
+		while ($row = $this->db->fetch_assoc($request))
+		{
+			$this->db->query("
+				UPDATE {$to_prefix}members
+				SET unread_messages = $row[real_num]
+				WHERE id_member = $row[id_member]
+				LIMIT 1");
+
+			pastTime(0);
+		}
+		$this->db->free_result($request);
+	}
+
+	/**
+	 * Count the topic likes based on first message id
+	 */
+	public function substep100()
+	{
+		$to_prefix = $this->config->to_prefix;
+
+		// Set the number of topic likes based on likes to the first message in the topic
+		$request = $this->db->query("
+			SELECT
+				COUNT(*) AS count, t.id_topic
+			FROM {$to_prefix}message_likes AS ml
+				INNER JOIN {$to_prefix}topics AS t ON (t.id_first_msg = ml.id_msg)
+			GROUP BY t.id_topic");
+		while ($row = $this->db->fetch_assoc($request))
+		{
+			$this->db->query("
+				UPDATE {$to_prefix}topics
+				SET num_likes = $row[count]
+				WHERE id_topic = $row[id_topic]
+				LIMIT 1");
+
+			pastTime(0);
+		}
+		$this->db->free_result($request);
+	}
+
+	/**
+	 * Validate / Update member likes received
+	 */
+	public function substep101()
+	{
+		$to_prefix = $this->config->to_prefix;
+
+		// Update the likes each member has received based on liked messages
+		$request = $this->db->query("
+			SELECT
+				COUNT(*) AS count, id_poster
+			FROM {$to_prefix}message_likes
+			GROUP BY id_poster");
+		while ($row = $this->db->fetch_assoc($request))
+		{
+			$this->db->query("
+				UPDATE {$to_prefix}members
+				SET likes_received = $row[count]
+				WHERE id_member = $row[id_poster]
+				LIMIT 1");
+
+			pastTime(0);
+		}
+		$this->db->free_result($request);
+	}
+
+	/**
+	 * Validate / Update likes given by a member
+	 */
+	public function substep102()
+	{
+		$to_prefix = $this->config->to_prefix;
+
+		// Update the likes each member has given
+		$request = $this->db->query("
+			SELECT
+				COUNT(*) AS count, id_member
+			FROM {$to_prefix}message_likes
+			GROUP BY id_member");
+		while ($row = $this->db->fetch_assoc($request))
+		{
+			$this->db->query("
+				UPDATE {$to_prefix}members
+				SET likes_given = $row[count]
+				WHERE id_member = $row[id_member]
+				LIMIT 1");
+
+			pastTime(0);
+		}
+		$this->db->free_result($request);
+	}
+}
+
+class elkarte1_1_importer_step3 extends Importers\SmfCommonSourceStep3
+{
+}

--- a/importer/Importers/elkarte1.1/smf2-0_importer.php
+++ b/importer/Importers/elkarte1.1/smf2-0_importer.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * @name      OpenImporter
+ * @copyright OpenImporter contributors
+ * @license   BSD http://opensource.org/licenses/BSD-3-Clause
+ *
+ * @version 1.0 Alpha
+ */
+
+/**
+ * Class SMF2_0
+ */
+class SMF2_0 extends Importers\AbstractSourceImporter
+{
+	protected $setting_file = '/Settings.php';
+
+	protected $smf_attach_folders = null;
+
+	protected $_is_nibogo_like = null;
+
+	public function getName()
+	{
+		return 'SMF2_0';
+	}
+
+	public function getVersion()
+	{
+		return 'ElkArte 1.1';
+	}
+
+	public function setDefines()
+	{
+		if (!defined('SMF'))
+			define('SMF', 1);
+	}
+
+	public function getPrefix()
+	{
+		$db_name = $this->getDbName();
+		$db_prefix = $this->fetchSetting('db_prefix');
+
+		return '`' . $db_name . '`.' . $db_prefix;
+	}
+
+	public function getDbName()
+	{
+		return $this->fetchSetting('db_name');
+	}
+
+	public function getTableTest()
+	{
+		return 'members';
+	}
+
+	protected function fetchSetting($name)
+	{
+		static $content = null;
+
+		if ($content === null)
+			$content = file_get_contents($this->path . '/Settings.php');
+
+		$match = array();
+		preg_match('~\$' . $name . '\s*=\s*\'(.*?)\';~', $content, $match);
+
+		return isset($match[1]) ? $match[1] : '';
+	}
+
+	/**
+	 * Read the attachment directory structure from the source db
+	 *
+	 * @return array|null
+	 */
+	public function getAttachmentDirs()
+	{
+		if ($this->smf_attach_folders === null)
+		{
+			$from_prefix = $this->config->from_prefix;
+
+			$request = $this->db->query("
+				SELECT value
+				FROM {$from_prefix}settings
+				WHERE variable='attachmentUploadDir';");
+			list ($smf_attachments_dir) = $this->db->fetch_row($request);
+
+			$this->smf_attach_folders = @unserialize($smf_attachments_dir);
+
+			if (!is_array($this->smf_attach_folders))
+				$this->smf_attach_folders = array(1 => $smf_attachments_dir);
+		}
+
+		return $this->smf_attach_folders;
+	}
+
+	/**
+	 * Import likes from one of the known addons
+	 *
+	 * @return array
+	 */
+	public function fetchLikes()
+	{
+		if ($this->isNibogo())
+			return $this->fetchNibogo();
+		else
+			return $this->fetchIllori();
+	}
+
+	/**
+	 * Nibogo version of likes
+	 *
+	 * @return array
+	 */
+	protected function fetchNibogo()
+	{
+		$from_prefix = $this->config->from_prefix;
+
+		$request = $this->db->query("
+			SELECT l.id_member, t.id_first_msg, t.id_member_started
+			FROM {$from_prefix}likes
+				INNER JOIN {$from_prefix}topics AS t ON (t.id_topic = l.id_topic)");
+		$return = array();
+		while ($row = $this->db->fetch_assoc($request))
+			$return[] = array(
+				'id_member' => $row['id_member'],
+				'id_msg' => $row['id_first_msg'],
+				'id_poster' => $row['id_member_started'],
+				'like_timestamp' => 0,
+			);
+		$this->db->free_result($request);
+
+		return $return;
+	}
+
+	/**
+	 * Illori version of likes
+	 *
+	 * @return array
+	 */
+	protected function fetchIllori()
+	{
+		$from_prefix = $this->config->from_prefix;
+
+		$request = $this->db->query("
+			SELECT l.id_member, l.id_message, m.id_member as id_poster
+			FROM {$from_prefix}likes AS l
+				INNER JOIN {$from_prefix}messages AS m ON (m.id_msg = l.id_message)");
+		$return = array();
+		while ($row = $this->db->fetch_assoc($request))
+			$return[] = array(
+				'id_member' => $row['id_member'],
+				'id_msg' => $row['id_message'],
+				'id_poster' => $row['id_poster'],
+				'like_timestamp' => 0,
+			);
+		$this->db->free_result($request);
+
+		return $return;
+	}
+
+	/**
+	 * Figure out which likes system may be in use
+	 *
+	 * @return bool|null
+	 */
+	protected function isNibogo()
+	{
+		$from_prefix = $this->config->from_prefix;
+
+		if ($this->_is_nibogo_like !== null)
+			return $this->_is_nibogo_like;
+
+		$request = $this->db->query("
+			SHOW COLUMNS
+			FROM {$from_prefix}likes");
+		while ($row = $this->db->fetch_assoc($request))
+		{
+			// This is Nibogo
+			if ($row['Field'] == 'id_topic')
+			{
+				$this->_is_nibogo_like = true;
+				return $this->_is_nibogo_like;
+			}
+		}
+
+		// Not Nibogo means Illori
+		$this->_is_nibogo_like = false;
+		return $this->_is_nibogo_like;
+	}
+}
+
+/**
+ * Copy attachments from the source to our destination
+ *
+ * @param array $row
+ * @param \OpenImporter\Database $db
+ * @param string $from_prefix
+ * @param string $attachmentUploadDir
+ */
+function moveAttachment(&$row, $db, $from_prefix, $attachmentUploadDir)
+{
+	static $smf_folders = null;
+
+	// We need to know where the attachments are located
+	if ($smf_folders === null)
+	{
+		$request = $db->query("
+			SELECT value
+			FROM {$from_prefix}settings
+			WHERE variable='attachmentUploadDir';");
+		list ($smf_attachments_dir) = $db->fetch_row($request);
+
+		$smf_folders = @unserialize($smf_attachments_dir);
+
+		if (!is_array($smf_folders))
+			$smf_folders = array(1 => $smf_attachments_dir);
+	}
+
+	// If something is broken, better try to account for it as well.
+	if (isset($smf_folders[$row['id_folder']]))
+		$smf_attachments_dir = $smf_folders[$row['id_folder']];
+	else
+		$smf_attachments_dir = $smf_folders[1];
+
+	// Missing the file hash ... create one
+	if (empty($row['file_hash']))
+	{
+		$row['file_hash'] = createAttachmentFileHash($row['filename']);
+		$source_file = $row['filename'];
+	}
+	else
+		$source_file = $row['id_attach'] . '_' . $row['file_hash'];
+
+	// Copy it over
+	copy_file($smf_attachments_dir . '/' . $source_file, $attachmentUploadDir . '/' . $row['id_attach'] . '_' . $row['file_hash'] . '.elk');
+}

--- a/importer/Importers/elkarte1.1/smf2-0_importer.xml
+++ b/importer/Importers/elkarte1.1/smf2-0_importer.xml
@@ -1,0 +1,799 @@
+<?xml version="1.0"?>
+<importer xmlns="http://www.elkarte.net/xml/importer" xmlns:elkarte="http://www.elkarte.net/">
+	<general>
+		<name>SMF 2.0</name>
+		<className>SMF2_0</className>
+		<version>Elkarte 1.1</version>
+	</general>
+	<step>
+		<title>Importing settings</title>
+		<detect>{$from_prefix}settings</detect>
+		<destination>{$to_prefix}settings</destination>
+		<options>
+			<replace>true</replace>
+		</options>
+		<code>
+			$do_import = array(
+				'news',
+				'compactTopicPagesContiguous',
+				'compactTopicPagesEnable',
+				'enablePinnedTopics',
+				'todayMod',
+				'enablePreviousNext',
+				'pollMode',
+				'enableVBStyleLogin',
+				'enableCompressedOutput',
+				'attachmentSizeLimit',
+				'attachmentPostLimit',
+				'attachmentNumPerPostLimit',
+				'attachmentDirSizeLimit',
+				'attachmentExtensions',
+				'attachmentCheckExtensions',
+				'attachmentShowImages',
+				'attachmentEnable',
+				'attachmentEncryptFilenames',
+				'attachmentThumbnails',
+				'attachmentThumbWidth',
+				'attachmentThumbHeight',
+				'censorIgnoreCase',
+				'mostOnline',
+				'mostOnlineToday',
+				'mostDate',
+				'allow_disableAnnounce',
+				'trackStats',
+				'userLanguage',
+				'titlesEnable',
+				'topicSummaryPosts',
+				'enableErrorLogging',
+				'max_image_width',
+				'max_image_height',
+				'onlineEnable',
+				'smtp_host',
+				'smtp_port',
+				'smtp_username',
+				'smtp_password',
+				'mail_type',
+				'timeLoadPageEnable',
+				'totalMembers',
+				'totalTopics',
+				'totalMessages',
+				'simpleSearch',
+				'censor_vulgar',
+				'censor_proper',
+				'enablePostHTML',
+				'enableEmbeddedFlash',
+				'xmlnews_enable',
+				'xmlnews_maxlen',
+				'hotTopicPosts',
+				'hotTopicVeryPosts',
+				'registration_method',
+				'send_validation_onChange',
+				'send_welcomeEmail',
+				'allow_editDisplayName',
+				'allow_hideOnline',
+				'guest_hideContacts',
+				'spamWaitTime',
+				'pm_spam_settings',
+				'reserveWord',
+				'reserveCase',
+				'reserveUser',
+				'reserveName',
+				'reserveNames',
+				'autoLinkUrls',
+				'banLastUpdated',
+				'avatar_max_height_external',
+				'avatar_max_width_external',
+				'avatar_action_too_large',
+				'avatar_max_height_upload',
+				'avatar_max_width_upload',
+				'avatar_resize_upload',
+				'avatar_download_png',
+				'failed_login_threshold',
+				'oldTopicDays',
+				'edit_wait_time',
+				'edit_disable_time',
+				'autoFixDatabase',
+				'allow_guestAccess',
+				'time_format',
+				'number_format',
+				'enableBBC',
+				'max_messageLength',
+				'signature_settings',
+				'autoOptMaxOnline',
+				'defaultMaxMessages',
+				'defaultMaxTopics',
+				'defaultMaxMembers',
+				'enableParticipation',
+				'recycle_enable',
+				'recycle_board',
+				'maxMsgID',
+				'enableAllMessages',
+				'fixLongWords',
+				'who_enabled',
+				'time_offset',
+				'cookieTime',
+				'lastActive',
+				'requireAgreement',
+				'unapprovedMembers',
+				'package_make_backups',
+				'databaseSession_enable',
+				'databaseSession_loose',
+				'databaseSession_lifetime',
+				'search_cache_size',
+				'search_results_per_page',
+				'search_weight_frequency',
+				'search_weight_age',
+				'search_weight_length',
+				'search_weight_subject',
+				'search_weight_first_message',
+				'search_max_results',
+				'search_floodcontrol_time',
+				'permission_enable_deny',
+				'permission_enable_postgroups',
+				'mail_next_send',
+				'mail_recent',
+				'settings_updated',
+				'next_task_time',
+				'warning_settings',
+				'admin_features',
+				'last_mod_report_action',
+				'pruningOptions',
+				'cache_enable',
+				'reg_verification',
+				'enable_buddylist',
+				'birthday_email',
+				'dont_repeat_theme_core',
+				'dont_repeat_smileys_20',
+				'globalCookies',
+				'default_timezone',
+				'memberlist_updated',
+				'latestMember',
+				'latestRealName',
+				'db_mysql_group_by_fix',
+				'rand_seed',
+				'mostOnlineUpdated',
+				'search_pointer',
+				'spider_name_cache',
+				'modlog_enabled',
+				'disabledBBC',
+				'latest_member',
+				'latest_real_name',
+				'total_members',
+				'total_messages',
+				'max_msg_id',
+				'total_topics',
+				'disable_hash_time',
+				'latestreal_name',
+				'disableHashTime',
+				'paid_enabled',
+				'paid_email',
+				'paid_email_to',
+				'paid_currency_code',
+				'paid_currency_symbol',
+				'paypal_email',
+				'smiley_enable',
+				'messageIcons_enable',
+				'disableHostnameLookup',
+				'approveAccountDeletion',
+				'avatar_download_external',
+				'spider_mode',
+				'calendar_updated',
+				'coppaAge',
+				'disallow_sendBody',
+				'enableErrorQueryLogging',
+				'hitStats',
+				'password_strength',
+				'custom_avatar_dir',
+				'custom_avatar_enabled',
+				'custom_avatar_url',
+				'mail_queue',
+			);
+
+			$request = $this->db->query("
+				SELECT variable, value
+				FROM {$from_prefix}settings;");
+
+			while ($row = $this->db->fetch_assoc($request))
+			{
+				if (in_array($row['variable'], $do_import))
+				{
+					$this->db->query("
+						REPLACE INTO {$to_prefix}settings
+							(variable, value)
+						VALUES('$row[variable]', '" . addcslashes($row['value'], '\'\\"') . "')");
+				}
+
+				if ($row['variable'] == 'pretty_board_urls')
+				{
+					$pretty_urls = $row['value'];
+					store_global('pretty_urls', $row['value']);
+				}
+			}
+
+			$this->db->free_result($request);
+		</code>
+	</step>
+	<step type="mandatory">
+		<title>Importing members</title>
+		<detect>{$from_prefix}members</detect>
+		<destination>{$to_prefix}members</destination>
+		<presql>TRUNCATE {$to_prefix}members;</presql>
+		<query>
+			SELECT
+				id_member, member_name, date_registered, posts, id_group, lngfile, last_login,
+				real_name, unread_messages, unread_messages, new_pm, buddy_list, pm_ignore_list,
+				pm_prefs, mod_prefs, message_labels, passwd, email_address,
+				birthdate, website_url, website_title, hide_email, show_online,
+				time_format, signature, time_offset, avatar, pm_email_notify,
+				usertitle, notify_announcements, notify_regularity, notify_send_body,
+				notify_types, member_ip, member_ip2, secret_question, secret_answer, 1 AS id_theme, is_activated,
+				validation_code, id_msg_last_visit, additional_groups, smiley_set, id_post_group,
+				total_time_logged_in, password_salt, ignore_boards,
+				IFNULL(warning, 0) AS warning, passwd_flood,
+				pm_receive_from AS receive_from
+			FROM {$from_prefix}members;
+		</query>
+	</step>
+	<step>
+		<title>Importing attachments</title>
+		<detect>{$from_prefix}attachments</detect>
+		<destination>{$to_prefix}attachments</destination>
+		<presql>TRUNCATE {$to_prefix}attachments;</presql>
+		<presqlMethod>removeAttachments</presqlMethod>
+		<preparsecode>
+			moveAttachment($row, $this->db, $this->config->from_prefix, $this->step1_importer->getAttachDir($row));
+		</preparsecode>
+		<query>
+			SELECT
+				id_attach, id_thumb, id_msg, id_member, attachment_type, filename, file_hash, size, downloads,
+				width, height, fileext, mime_type, id_folder
+			FROM {$from_prefix}attachments;
+		</query>
+	</step>
+	<step>
+		<title>Importing avatars</title>
+		<code>
+			// First check avatar_directory
+			$avatarg = $this->db->query("
+				SELECT value
+				FROM {$from_prefix}settings
+				WHERE variable = 'avatar_directory';");
+			list ($smf_avatarg) = $this->db->fetch_row($avatarg);
+			$this->db->free_result($avatarg);
+
+			$avatarg = $this->db->query("
+				SELECT value
+				FROM {$to_prefix}settings
+				WHERE variable = 'avatar_directory';");
+			list ($elk_avatarg) = $this->db->fetch_row($avatarg);
+			$this->db->free_result($avatarg);
+
+			if (!empty($smf_avatarg) and !empty($elk_avatarg))
+				copy_dir_recursive($smf_avatarg, $elk_avatarg);
+
+			// Next check custom_avatar_dir
+			$avatarg = $this->db->query("
+				SELECT value
+				FROM {$from_prefix}settings
+				WHERE variable = 'custom_avatar_dir';");
+			list ($smf_avatarg) = $this->db->fetch_row($avatarg);
+			$this->db->free_result($avatarg);
+
+			$avatarg = $this->db->query("
+				SELECT value
+				FROM {$to_prefix}settings
+				WHERE variable = 'custom_avatar_dir';");
+			list ($elk_avatarg) = $this->db->fetch_row($avatarg);
+			$this->db->free_result($avatarg);
+
+			if (!empty($smf_avatarg) and !empty($elk_avatarg))
+				copy_dir_recursive($smf_avatarg, $elk_avatarg);
+		</code>
+	</step>
+	<step>
+		<title>Importing categories</title>
+		<detect>{$from_prefix}categories</detect>
+		<destination>{$to_prefix}categories</destination>
+		<presql>TRUNCATE {$to_prefix}categories;</presql>
+		<query>
+			SELECT
+				id_cat, name, cat_order, can_collapse
+			FROM {$from_prefix}categories;
+		</query>
+	</step>
+	<step>
+		<title>Importing collapsed categories</title>
+		<detect>{$from_prefix}collapsed_categories</detect>
+		<destination>{$to_prefix}collapsed_categories</destination>
+		<presql>TRUNCATE {$to_prefix}collapsed_categories;</presql>
+		<query>
+			SELECT
+				id_cat, id_member
+			FROM {$from_prefix}collapsed_categories;
+		</query>
+	</step>
+	<step>
+		<title>Importing boards</title>
+		<detect>{$from_prefix}boards</detect>
+		<destination>{$to_prefix}boards</destination>
+		<presql>TRUNCATE {$to_prefix}boards;</presql>
+		<query>
+			SELECT
+				id_board, id_cat, child_level, id_parent, board_order, id_last_msg, id_msg_updated, member_groups,
+				id_profile, name, description, num_topics, num_posts, count_posts, id_theme,
+				override_theme, unapproved_posts, unapproved_topics, redirect
+			FROM {$from_prefix}boards;
+		</query>
+	</step>
+	<step>
+		<title>Importing topics</title>
+		<detect>{$from_prefix}topics</detect>
+		<destination>{$to_prefix}topics</destination>
+		<presql>TRUNCATE {$to_prefix}topics;</presql>
+		<query>
+			SELECT
+				id_topic, is_sticky, id_board, id_first_msg, id_last_msg, id_member_started,
+				id_member_updated, id_poll,id_previous_board, id_previous_topic, num_replies,
+				num_views, locked, unapproved_posts, approved
+			FROM {$from_prefix}topics;
+		</query>
+	</step>
+	<step>
+		<title>Importing messages</title>
+		<detect>{$from_prefix}messages</detect>
+		<destination>{$to_prefix}messages</destination>
+		<presql>TRUNCATE {$to_prefix}messages;</presql>
+		<options>
+			<limit>100</limit>
+		</options>
+		<query>
+			SELECT
+				id_msg, id_topic, id_board, poster_time, id_member, id_msg_modified, subject, poster_name,
+				poster_email, poster_ip, smileys_enabled, modified_time, modified_name, body, icon, approved
+			FROM {$from_prefix}messages;
+		</query>
+	</step>
+	<step>
+		<title>Importing polls</title>
+		<detect>{$from_prefix}polls</detect>
+		<destination>{$to_prefix}polls</destination>
+		<presql>TRUNCATE {$to_prefix}polls;</presql>
+		<query>
+			SELECT
+				id_poll, question, voting_locked, max_votes, expire_time, hide_results, change_vote,
+				guest_vote, num_guest_voters, reset_poll, id_member, poster_name
+			FROM {$from_prefix}polls;
+		</query>
+	</step>
+	<step>
+		<title>Importing poll choices</title>
+		<detect>{$from_prefix}poll_choices</detect>
+		<destination>{$to_prefix}poll_choices</destination>
+		<presql>TRUNCATE {$to_prefix}poll_choices;</presql>
+		<query>
+			SELECT
+				id_poll, id_choice, label, votes
+			FROM {$from_prefix}poll_choices;
+		</query>
+	</step>
+	<step>
+		<title>Importing poll votes</title>
+		<detect>{$from_prefix}log_polls</detect>
+		<destination>{$to_prefix}log_polls</destination>
+		<presql>TRUNCATE {$to_prefix}log_polls;</presql>
+		<query>
+			SELECT
+				id_poll, id_member, id_choice
+			FROM {$from_prefix}log_polls;
+		</query>
+	</step>
+	<step>
+		<title>Importing personal messages</title>
+		<detect>{$from_prefix}personal_messages</detect>
+		<destination>{$to_prefix}personal_messages</destination>
+		<presql>TRUNCATE {$to_prefix}personal_messages;</presql>
+		<options>
+			<limit>200</limit>
+		</options>
+		<query>
+			SELECT
+				id_pm, id_pm_head, id_member_from, deleted_by_sender, from_name,
+				msgtime, subject, body
+			FROM {$from_prefix}personal_messages;
+		</query>
+	</step>
+	<step>
+		<title>Importing pm recipients</title>
+		<detect>{$from_prefix}pm_recipients</detect>
+		<destination>{$to_prefix}pm_recipients</destination>
+		<presql>TRUNCATE {$to_prefix}pm_recipients;</presql>
+		<query>
+			SELECT
+				id_pm, id_member, labels, bcc, is_read, is_new, deleted
+			FROM {$from_prefix}pm_recipients;
+		</query>
+	</step>
+	<step>
+		<title>Importing pm rules</title>
+		<detect>{$from_prefix}pm_rules</detect>
+		<destination>{$to_prefix}pm_rules</destination>
+		<presql>TRUNCATE {$to_prefix}pm_rules;</presql>
+		<query>
+			SELECT
+				id_rule, id_member, rule_name, criteria, actions, delete_pm, is_or
+			FROM {$from_prefix}pm_rules;
+		</query>
+	</step>
+	<step>
+		<title>Importing board moderators</title>
+		<detect>{$from_prefix}moderators</detect>
+		<destination>{$to_prefix}moderators</destination>
+		<presql>TRUNCATE {$to_prefix}moderators;</presql>
+		<query>
+			SELECT
+				id_board, id_member
+			FROM {$from_prefix}moderators;
+		</query>
+	</step>
+	<step>
+		<title>Importing mark read data (boards)</title>
+		<detect>{$from_prefix}log_boards</detect>
+		<destination>{$to_prefix}log_boards</destination>
+		<presql>TRUNCATE {$to_prefix}log_boards;</presql>
+		<query>
+			SELECT
+				id_member, id_board, id_msg
+			FROM {$from_prefix}log_boards;
+		</query>
+	</step>
+	<step>
+		<title>Importing mark read data (topics)</title>
+		<detect>{$from_prefix}log_topics</detect>
+		<destination>{$to_prefix}log_topics</destination>
+		<presql>TRUNCATE {$to_prefix}log_topics;</presql>
+		<query>
+			SELECT
+				id_member, id_topic, id_msg
+			FROM {$from_prefix}log_topics;
+		</query>
+	</step>
+	<step>
+		<title>Importing mark read data</title>
+		<detect>{$from_prefix}log_mark_read</detect>
+		<destination>{$to_prefix}log_mark_read</destination>
+		<presql>TRUNCATE {$to_prefix}log_mark_read;</presql>
+		<query>
+			SELECT
+				id_member, id_board, id_msg
+			FROM {$from_prefix}log_mark_read;
+		</query>
+	</step>
+	<step>
+		<title>Importing notifications</title>
+		<detect>{$from_prefix}log_notify</detect>
+		<destination>{$to_prefix}log_notify</destination>
+		<presql>TRUNCATE {$to_prefix}log_notify;</presql>
+		<query>
+			SELECT
+				id_member, id_topic, id_board, sent
+			FROM {$from_prefix}log_notify;
+		</query>
+	</step>
+	<step>
+		<title>Importing membergroups</title>
+		<detect>{$from_prefix}membergroups</detect>
+		<destination>{$to_prefix}membergroups</destination>
+		<options>
+			<replace>true</replace>
+		</options>
+		<query>
+			SELECT
+				id_group, group_name, description, online_color, min_posts,
+				max_messages, stars AS icons, group_type, hidden, id_parent
+			FROM {$from_prefix}membergroups;
+		</query>
+	</step>
+	<step>
+		<title>Importing group moderators</title>
+		<detect>{$from_prefix}group_moderators</detect>
+		<destination>{$to_prefix}group_moderators</destination>
+		<options>
+			<replace>true</replace>
+		</options>
+		<query>
+			SELECT
+				id_group, id_member
+			FROM {$from_prefix}group_moderators;
+		</query>
+	</step>
+	<step>
+		<title>Importing permission profiles</title>
+		<detect>{$from_prefix}permission_profiles</detect>
+		<destination>{$to_prefix}permission_profiles</destination>
+		<options>
+			<replace>true</replace>
+		</options>
+		<query>
+			SELECT
+				id_profile, profile_name
+			FROM {$from_prefix}permission_profiles;
+		</query>
+	</step>
+	<step>
+		<title>Importing permissions</title>
+		<detect>{$from_prefix}permissions</detect>
+		<destination>{$to_prefix}permissions</destination>
+		<options>
+			<replace>true</replace>
+		</options>
+		<query>
+			SELECT
+				id_group, permission, add_deny
+			FROM {$from_prefix}permissions;
+		</query>
+	</step>
+	<step>
+		<title>Importing board permissions</title>
+		<detect>{$from_prefix}board_permissions</detect>
+		<destination>{$to_prefix}board_permissions</destination>
+		<options>
+			<replace>true</replace>
+		</options>
+		<query>
+			SELECT
+				id_group, id_profile, permission, add_deny
+			FROM {$from_prefix}board_permissions;
+		</query>
+	</step>
+	<step>
+		<title>Importing smileys</title>
+		<detect>{$from_prefix}smileys</detect>
+		<destination>{$to_prefix}smileys</destination>
+		<options>
+			<replace>true</replace>
+		</options>
+		<query>
+			SELECT
+				id_smiley, code, filename, description, smiley_row,
+				smiley_order, hidden
+			FROM {$from_prefix}smileys;
+		</query>
+	</step>
+	<step>
+		<title>Copying smileys</title>
+		<detect>{$from_prefix}smileys</detect>
+		<code>
+			$request = $this->db->query("
+				SELECT value
+				FROM {$to_prefix}settings
+				WHERE variable='smileys_dir';");
+			list ($smileys_dir) = $this->db->fetch_row($request);
+
+			$request = $this->db->query("
+				SELECT value
+				FROM {$from_prefix}settings
+				WHERE variable='smileys_dir';");
+			list ($smf_smileys_dir) = $this->db->fetch_row($request);
+
+			copy_smileys($smf_smileys_dir, $smileys_dir);
+		</code>
+	</step>
+	<step>
+		<title>Importing statistics (activity log)</title>
+		<detect>{$from_prefix}log_activity</detect>
+		<destination>{$to_prefix}log_activity</destination>
+		<presql>TRUNCATE {$to_prefix}log_activity;</presql>
+		<query>
+			SELECT
+				date, hits, topics, posts, registers, most_on
+			FROM {$from_prefix}log_activity;
+		</query>
+	</step>
+	<step>
+		<title>Importing logged actions</title>
+		<detect>{$from_prefix}log_actions</detect>
+		<destination>{$to_prefix}log_actions</destination>
+		<presql>TRUNCATE {$to_prefix}log_actions;</presql>
+		<query>
+			SELECT
+				id_action, id_log, log_time, id_member, ip, action, id_board,
+				id_topic, id_msg, extra
+			FROM {$from_prefix}log_actions;
+		</query>
+	</step>
+	<step>
+		<title>Importing reported posts</title>
+		<detect>{$from_prefix}log_reported</detect>
+		<destination>{$to_prefix}log_reported</destination>
+		<presql>TRUNCATE {$to_prefix}log_reported;</presql>
+		<query>
+			SELECT
+				id_report, id_msg, id_topic, id_board, id_member, membername, subject,
+				body, time_started, time_updated, num_reports, closed, ignore_all
+			FROM {$from_prefix}log_reported;
+		</query>
+	</step>
+	<step>
+		<title>Importing reported comments</title>
+		<detect>{$from_prefix}log_reported_comments</detect>
+		<destination>{$to_prefix}log_reported_comments</destination>
+		<presql>TRUNCATE {$to_prefix}log_reported_comments;</presql>
+		<query>
+			SELECT
+				id_comment, id_report, id_member, membername, comment, time_sent
+			FROM {$from_prefix}log_reported_comments;
+		</query>
+	</step>
+	<step>
+		<title>Importing spider hits</title>
+		<detect>{$from_prefix}log_spider_hits</detect>
+		<destination>{$to_prefix}log_spider_hits</destination>
+		<presql>TRUNCATE {$to_prefix}log_spider_hits;</presql>
+		<query>
+			SELECT
+				id_hit, id_spider, log_time, url, processed
+			FROM {$from_prefix}log_spider_hits;
+		</query>
+	</step>
+	<step>
+		<title>Importing spider stats</title>
+		<detect>{$from_prefix}log_spider_stats</detect>
+		<destination>{$to_prefix}log_spider_stats</destination>
+		<presql>TRUNCATE {$to_prefix}log_spider_stats;</presql>
+		<query>
+			SELECT
+				id_spider, page_hits, last_seen, stat_date
+			FROM {$from_prefix}log_spider_stats;
+		</query>
+	</step>
+	<step>
+		<title>Importing subscriptions</title>
+		<detect>{$from_prefix}subscriptions</detect>
+		<destination>{$to_prefix}subscriptions</destination>
+		<presql>TRUNCATE {$to_prefix}subscriptions;</presql>
+		<query>
+			SELECT
+				id_subscribe, name, description, cost, length, id_group,
+				add_groups, active, repeatable, allow_partial, reminder, email_complete
+			FROM {$from_prefix}subscriptions;
+		</query>
+	</step>
+	<step>
+		<title>Importing custom fields</title>
+		<detect>{$from_prefix}custom_fields</detect>
+		<destination>{$to_prefix}custom_fields</destination>
+		<presql>TRUNCATE {$to_prefix}custom_fields;</presql>
+		<query>
+			SELECT
+				col_name, field_name, field_desc, field_type, field_length,
+				field_options, mask, show_reg, show_display, show_profile, private,
+				active, bbc, can_search, default_value, enclose, placement
+			FROM {$from_prefix}custom_fields;
+		</query>
+	</step>
+	<step>
+		<title>Converting memberdata to custom fields</title>
+		<options>
+			<replace>true</replace>
+		</options>
+		<code>
+			$this->db->query("
+				REPLACE INTO {$to_prefix}custom_fields
+					(col_name, field_name, field_desc, field_type, field_length, field_options, mask, show_reg, show_display, show_profile, private, active, bbc, can_search, default_value, enclose, placement, rows, cols)
+				VALUES('cust_gender', 'Gender', 'Your gender', 'radio', 15, 'undisclosed,male,female,genderless,nonbinary,transgendered', '', 0, 1, 'forumprofile', 0, 1, 0, 0, 'undisclosed', '<i class="icon i-{KEY}" title="{INPUT}"><s>{INPUT}</s></i>', 0, 0, 0)
+			");
+			$this->db->query("
+				REPLACE INTO {$to_prefix}custom_fields
+					(col_name, field_name, field_desc, field_type, field_length, field_options, mask, show_reg, show_display, show_profile, private, active, bbc, can_search, default_value, enclose, placement, rows, cols)
+				VALUES('cust_blurb', 'Personal Text', 'A custom bit of text for your postbit.', 'text', 120, '', '', 0, 0, 'forumprofile', 0, 1, 0, 0, 'Default Personal Text', '', 3, 0, 0)
+			");
+			$this->db->query("
+				REPLACE INTO {$to_prefix}custom_fields
+					(col_name, field_name, field_desc, field_type, field_length, field_options, mask, show_reg, show_display, show_profile, private, active, bbc, can_search, default_value, enclose, placement, rows, cols)
+				VALUES('cust_locate', 'Location', 'Where you are', 'text', 32, '', '', 0, 0, 'forumprofile', 0, 1, 0, 0, '', '', 0, 0, 0)
+			");
+		</code>
+	</step>
+	<step>
+		<title>Importing custom fields data</title>
+		<detect>{$from_prefix}custom_fields</detect>
+		<destination>{$to_prefix}custom_fields_data</destination>
+		<presql>TRUNCATE {$to_prefix}custom_fields_data;</presql>
+		<query>
+			SELECT
+				id_member, variable, value
+			FROM {$from_prefix}themes
+			WHERE variable LIKE 'cust\_%';
+		</query>
+	</step>
+	<step>
+		<title>Importing gender data (1/3)</title>
+		<detect>{$from_prefix}members</detect>
+		<destination>{$to_prefix}custom_fields_data</destination>
+		<query>
+			SELECT
+			id_member, 'cust_gender' AS variable, 'undisclosed' AS value
+			FROM {$from_prefix}members
+			WHERE gender=0;
+		</query>
+	</step>
+	<step>
+		<title>Importing gender data (2/3)</title>
+		<detect>{$from_prefix}members</detect>
+		<destination>{$to_prefix}custom_fields_data</destination>
+		<query>
+			SELECT
+			id_member, 'cust_gender' AS variable, 'male' AS value
+			FROM {$from_prefix}members
+			WHERE gender=1;
+		</query>
+	</step>
+	<step>
+		<title>Importing gender data (3/3)</title>
+		<detect>{$from_prefix}members</detect>
+		<destination>{$to_prefix}custom_fields_data</destination>
+		<query>
+			SELECT
+			id_member, 'cust_gender' AS variable, 'female' AS value
+			FROM {$from_prefix}members
+			WHERE gender=2;
+		</query>
+	</step>
+	<step>
+		<title>Importing custom text data</title>
+		<detect>{$from_prefix}members</detect>
+		<destination>{$to_prefix}custom_fields_data</destination>
+		<query>
+			SELECT
+			id_member, 'cust_locate' AS variable, location AS value
+			FROM {$from_prefix}members
+			WHERE location != '';
+		</query>
+	</step>
+	<step>
+		<title>Importing personal text data</title>
+		<detect>{$from_prefix}members</detect>
+		<destination>{$to_prefix}custom_fields_data</destination>
+		<query>
+			SELECT
+			id_member, 'cust_blurb' AS variable, personal_text AS value
+			FROM {$from_prefix}members
+			WHERE personal_text != '';
+		</query>
+	</step>
+	<step>
+		<title>Importing likes from Thank you mod</title>
+		<detect>{$from_prefix}thank_you_post</detect>
+		<destination>{$to_prefix}message_likes</destination>
+		<presql>TRUNCATE {$to_prefix}message_likes;</presql>
+		<query>
+			SELECT th.id_member, th.id_msg, m.id_member AS id_poster, th.thx_time AS like_timestamp
+			FROM {$from_prefix}thank_you_post AS th
+				LEFT JOIN {$from_prefix}topics AS t ON (th.id_topic = t.id_topic)
+				LEFT JOIN {$from_prefix}messages AS m ON (th.id_msg = m.id_msg);
+		</query>
+	</step>
+	<step>
+		<title>Importing likes from Joker's Like Posts mod</title>
+		<detect>{$from_prefix}like_post</detect>
+		<destination>{$to_prefix}message_likes</destination>
+		<presql>TRUNCATE {$to_prefix}message_likes;</presql>
+		<query>
+			SELECT lp.id_member_received AS id_member, lp.id_msg, lp.id_member_gave AS id_poster, lp.liked_timestamp AS like_timestamp
+			FROM {$from_prefix}like_post AS lp;
+		</query>
+	</step>
+	<step>
+		<title>Importing likes from Nibogo's Likes Lite or Illori's SMF Likes Plus mods</title>
+		<detect>{$from_prefix}likes</detect>
+		<destination>{$to_prefix}message_likes</destination>
+		<presql>TRUNCATE {$to_prefix}message_likes;</presql>
+		<code>
+			$this->keys = array('id_member', 'id_msg', 'id_poster', 'like_timestamp');
+			$this->rows = $this->config->source->fetchLikes();
+			$special_table = $this->config->to_prefix . 'message_likes';
+
+			$this->insertRows($special_table);
+		</code>
+	</step>
+</importer>


### PR DESCRIPTION
The only change needed here seemed to be handling the member columns I moved to custom fields.

As mentioned I also added a number of SMF 2.0 settings that Elkarte still uses that weren't getting imported. Custom avatar directories (I didn't add this to the 1.0 converter) are brought in without converting - they still point to the old directory so be mindful if you have them in a subfolder.